### PR TITLE
Add support for multiple backup destinations

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,16 +96,16 @@ name/value pairs:
 * **version** The string "2.0".
 * **backup-dir** A string that contains the base directory where the backups will go. This directory
                  must exist prior to the execution of the backup program.
-* **backup-sets**: An array of backup sets.
+* **backup-sets** An array of backup sets.
 
 The backup sets are objects that contain the following name/value pairs:
 
 * **set-name** A string identifying the backup set. This set name will be used to create a
                subdirectory in `backup-dir`.
 * **type** The type of backup, either "local dir" or "remote dir".
-* **remote-shell**: (only when `type` is "remote dir") The remote shell to use for connecting with
-                    the remote host. The string includes the options that the remote shell needs to
-                    connect to the remote host.
+* **remote-shell** (only when `type` is "remote dir") The remote shell to use for connecting with
+                   the remote host. The string includes the options that the remote shell needs to
+                   connect to the remote host.
 * **remote-host** (only when `type` is "remote dir") The remote host to connect to. This can include
                   a remote user (with the syntax "\<user\>@\<host\>") that the remote rsync process
                   will use to execute its task.

--- a/README.md
+++ b/README.md
@@ -51,18 +51,21 @@ available without manually activating the virtual environment.
 ### Configuration
 
 The configuration for _backupbrace_ is stored in a JSON-file. The file is versioned. This version of
-the program uses version 2.0 of the configuration file. It is also compatible with any other 2.x
+the program uses version 3.0 of the configuration file. It is also compatible with any other 3.x
 version of the configuration file.
 
-Version 2.0 supports the backup of local and remote files and directories to a local backup
-directory.
+Version 3.0 supports the backup of local and remote files and directories to one or more local
+backup directories.
 
-A sample version 2.0 configuration file looks as follows:
+A sample version 3.0 configuration file looks as follows:
 
 ```json
 {
-   "version": "2.0",
-   "backup-dir": "/path/to/backup/dir",
+   "version": "3.0",
+   "backup-dirs": [
+      "/path/to/backup/dir_1",
+      "/path/to/backup/dir_2"
+   ],
    "backup-sets": [
       {
          "set-name": "set_1",
@@ -93,9 +96,10 @@ A sample version 2.0 configuration file looks as follows:
 The configuration is contained in a single, unnamed JSON object. The object contains the following
 name/value pairs:
 
-* **version** The string "2.0".
-* **backup-dir** A string that contains the base directory where the backups will go. This directory
-                 must exist prior to the execution of the backup program.
+* **version** The string "3.0".
+* **backup-dirs** An array of strings that contain the base directories where the backups will go.
+                  When a directory does not exist, the backup to that directory will be skipped
+                  silently.
 * **backup-sets** An array of backup sets.
 
 The backup sets are objects that contain the following name/value pairs:

--- a/closingbrace/backupbrace.py
+++ b/closingbrace/backupbrace.py
@@ -12,6 +12,7 @@ from closingbrace.backuperror import BackupError
 from closingbrace.backupmanager import BackupManager
 from closingbrace.configuration import Configuration
 from closingbrace.environment import Environment
+from os import path
 
 def create_backup(backup_dir, backup_sets):
     """Create a backup of backup_sets in backup_dir.
@@ -55,8 +56,9 @@ def run():
         sys.exit(0)
     try:
         conf = Configuration(env.conffile)
-        create_backup(conf.get_param("backup-dir"),
-                conf.get_param("backup-sets"))
+        backup_dir = conf.get_param("backup-dir")
+        if path.isdir(backup_dir):
+            create_backup(backup_dir, conf.get_param("backup-sets"))
     except BackupError as e:
         logging.error("Backup incomplete due to error:")
         logging.error("  {0}".format(e))

--- a/closingbrace/backupbrace.py
+++ b/closingbrace/backupbrace.py
@@ -1,7 +1,7 @@
 # Backupbrace
 # A script to create backups of a Linux system.
 #
-# Copyright (c) 2015-2020 Hans Vredeveld
+# Copyright (c) 2015-2021 Hans Vredeveld
 #
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -13,6 +13,41 @@ from closingbrace.backupmanager import BackupManager
 from closingbrace.configuration import Configuration
 from closingbrace.environment import Environment
 
+def create_backup(backup_dir, backup_sets):
+    """Create a backup of backup_sets in backup_dir.
+
+    Args:
+        backup_dir : The base directory to write the backup to.
+        backup_sets: The backup sets to make a backup of.
+
+    Raises:
+        BackupError: When there was an error creating the backup.
+    """
+    manager = BackupManager(backup_dir)
+    backup = manager.new_backup()
+    for backup_set in backup_sets:
+        if (backup_set["type"] == "local dir"):
+            name = backup_set["set-name"]
+            src_dir = backup_set["source-dir"]
+            if "skip-entries" in backup_set:
+                skip_entries = backup_set["skip-entries"]
+            else:
+                skip_entries = None
+            backup.add_local_dir_set(name, src_dir, skip_entries)
+        elif (backup_set["type"] == "remote dir"):
+            name = backup_set["set-name"]
+            src_dir = backup_set["source-dir"]
+            remote_host = backup_set["remote-host"]
+            remote_shell = backup_set["remote-shell"]
+            if "skip-entries" in backup_set:
+                skip_entries = backup_set["skip-entries"]
+            else:
+                skip_entries = None
+            backup.add_remote_dir_set(name, src_dir, remote_host,
+                    remote_shell, skip_entries)
+    backup.create(manager.find_latest_set)
+
+
 def run():
     env = Environment()
     if (env.conf_format):
@@ -20,29 +55,8 @@ def run():
         sys.exit(0)
     try:
         conf = Configuration(env.conffile)
-        manager = BackupManager(conf.get_param("backup-dir"))
-        backup = manager.new_backup()
-        for backup_set in conf.get_param("backup-sets"):
-            if (backup_set["type"] == "local dir"):
-                name = backup_set["set-name"]
-                src_dir = backup_set["source-dir"]
-                if "skip-entries" in backup_set:
-                    skip_entries = backup_set["skip-entries"]
-                else:
-                    skip_entries = None
-                backup.add_local_dir_set(name, src_dir, skip_entries)
-            elif (backup_set["type"] == "remote dir"):
-                name = backup_set["set-name"]
-                src_dir = backup_set["source-dir"]
-                remote_host = backup_set["remote-host"]
-                remote_shell = backup_set["remote-shell"]
-                if "skip-entries" in backup_set:
-                    skip_entries = backup_set["skip-entries"]
-                else:
-                    skip_entries = None
-                backup.add_remote_dir_set(name, src_dir, remote_host,
-                        remote_shell, skip_entries)
-        backup.create(manager.find_latest_set)
+        create_backup(conf.get_param("backup-dir"),
+                conf.get_param("backup-sets"))
     except BackupError as e:
         logging.error("Backup incomplete due to error:")
         logging.error("  {0}".format(e))

--- a/closingbrace/backupbrace.py
+++ b/closingbrace/backupbrace.py
@@ -56,9 +56,10 @@ def run():
         sys.exit(0)
     try:
         conf = Configuration(env.conffile)
-        backup_dir = conf.get_param("backup-dir")
-        if path.isdir(backup_dir):
-            create_backup(backup_dir, conf.get_param("backup-sets"))
+        backup_dirs = conf.get_param("backup-dirs")
+        for backup_dir in backup_dirs:
+            if path.isdir(backup_dir):
+                create_backup(backup_dir, conf.get_param("backup-sets"))
     except BackupError as e:
         logging.error("Backup incomplete due to error:")
         logging.error("  {0}".format(e))

--- a/closingbrace/configuration.py
+++ b/closingbrace/configuration.py
@@ -1,7 +1,7 @@
 # Backupbrace
 # A script to create backups of a Linux system.
 #
-# Copyright (c) 2015-2020 Hans Vredeveld
+# Copyright (c) 2015-2021 Hans Vredeveld
 #
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -16,7 +16,7 @@ class Configuration:
 
     The configuration is read from a json-configuration file. This
     configuration file is versioned. The program only supports
-    configuration files in the version 2.0 format.
+    configuration files in the version 3.0 format.
 
     Attributes:
         version_major (str): The major part of the configuration's
@@ -94,11 +94,11 @@ class Configuration:
             BackupError: When the configuration format version is not
                          supported.
         """
-        if (int(self.version_major) == 2) and (int(self.version_minor) >= 0):
+        if (int(self.version_major) == 3) and (int(self.version_minor) >= 0):
             # We have a supported version
             return
         raise BackupError("Configuration file format not supported. Found "
-                "version {0}, only supporting versions 2.x".
+                "version {0}, only supporting versions 3.x".
                 format(self._configuration["version"]))
 
     @classmethod
@@ -108,17 +108,20 @@ class Configuration:
         print(textwrap.dedent("""\
             The configuration for the backup program is stored in a JSON-file.
             The file is versioned. This version of the program uses version
-            2.0 of the configuration file. It is also compatible with any other
-            2.x version of the configuration file.
+            3.0 of the configuration file. It is also compatible with any other
+            3.x version of the configuration file.
 
-            Version 2.0 supports the backup of local and remote files and
-            directories to a local backup directory.
+            Version 3.0 supports the backup of local and remote files and
+            directories to one or more local backup directories.
 
-            A sample version 2.0 configuration file looks as follows:
+            A sample version 3.0 configuration file looks as follows:
 
                 {
-                   "version": "2.0",
-                   "backup-dir": "/path/to/backup/dir",
+                   "version": "3.0",
+                   "backup-dirs": [
+                      "/path/to/backup/dir_1",
+                      "/path/to/backup/dir_2"
+                   ],
                    "backup-sets": [
                       {
                          "set-name": "set_1",
@@ -147,10 +150,11 @@ class Configuration:
 
             The configuration is contained in a single, unnamed JSON object. The
             object contains the following name/value pairs:
-            - `version`    : The string "2.0".
-            - `backup-dir` : A string that contains the base directory where the
-                             backups will go. This directory must exist prior to
-                             the execution of the backup program.
+            - `version`    : The string "3.0".
+            - `backup-dirs`: An array of strings that contains the base
+                             directories where the backups will go. When a
+                             directory does not exist, the backup to that
+                             directory will be skipped silently.
             - `backup-sets`: An array of backup sets.
 
             The backup sets are objects that contain the following name/value


### PR DESCRIPTION
# Description

This pull request adds support for multiple backup destinations.

Fixes issue #2 

# How Has This Been Tested?

A test configuration was made with two destination directories. With this configuration, three tests were executed in succession:
1. The first destination directory exists, the second does not.
2. Both destination directories exist.
3. The first destination directory does not exist, the second does.

# Checklist:

- [X ] My code follows the style guidelines of this project
- [ X] I have performed a self-review of my own code
- [ X] I have commented my code where necessary, particularly in hard-to-understand areas
- [ X] I have made corresponding changes to the documentation
- [ X] Any dependent changes have been merged and published in downstream modules
